### PR TITLE
fix: Add a checkout step to make sure the python version can be determined from the pyproject.toml file

### DIFF
--- a/.github/workflows/_reusable-package-testpypi.yml
+++ b/.github/workflows/_reusable-package-testpypi.yml
@@ -68,6 +68,7 @@ jobs:
     permissions:
       contents: read
     steps:
+      - uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
## Proposed changes

This fixes a bug in the `_reusable-package-testpypi.yml` file where the python version can't be determined from the pyproject.toml file since the file doesn't exist.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have followed the guidelines in the [CONTRIBUTING](https://github.com/tektronix/python-package-ci-cd/blob/main/CONTRIBUTING.md) document
- [ ] I have signed the CLA
- [ ] I have checked to ensure there aren't other open [Pull Requests](https://github.com/tektronix/python-package-ci-cd/pulls) for the same update/change
- [ ] I have created (or updated) an [Issue](https://github.com/tektronix/python-package-ci-cd/issues) to track the status of this update/change and updated the link in this PR description (see above in the **Proposed changes** section) using the wording `Addresses #<issue_number>`
- [ ] I have performed a self-review of my code
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] Basic linting passes locally with my changes
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have updated the Changelog with a brief description of my changes
