### PR TITLE
refactor: Disable the pre-commit cache on Windows since the time to unpack is more than the pre-commit installation time

### DIFF
--- a/.github/workflows/_reusable-test-code.yml
+++ b/.github/workflows/_reusable-test-code.yml
@@ -51,6 +51,7 @@ jobs:
       - name: Install dependencies
         run: python -m pip install tox tox-gh-actions
       - name: Set up pre-commit cache
+        if: ${{ matrix.os-name != 'windows' }}
         uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9  # v4.0.2
         with:
           path: ~/.cache/pre-commit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ Things to be included in the next release go here.
 - Changed the `_reusable-update-python-and-pre-commit-dependencies.yml` workflow to no longer only work on PRs from Dependabot, users will now need to apply any conditional login in the calling workflow.
 - Updated the `_reusable-update-python-and-pre-commit-dependencies.yml` workflow to allow using [`renovate`](https://docs.renovatebot.com/) instead of Dependabot to update dependencies.
 
+### Removed
+
+- Removed the `pre-commit` cache from the `_reusable-test-code.yml` workflow to speed up the workflow. This should be a transparent change to users of the workflow (no changes required for any users).
+
 ---
 
 ## v1.2.0 (2024-08-30)


### PR DESCRIPTION
## Proposed changes

This disables the `pre-commit` cache on Windows runners to prevent the cache unpacking from taking a long time. It is usually faster to install the `pre-commit` hooks than to restore the cache.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Functionality update (non-breaking change which updates or changes existing functionality)
- [x] CI/CD update (an update to the CI/CD workflows, scripts, and/or configurations)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have followed the guidelines in the [CONTRIBUTING](https://github.com/tektronix/python-package-ci-cd/blob/main/CONTRIBUTING.md) document
- [x] I have signed the CLA
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/tektronix/python-package-ci-cd/pulls) for the same update/change
- [x] I have created (or updated) an [Issue](https://github.com/tektronix/python-package-ci-cd/issues) to track the status of this update/change and updated the link in this PR description (see above in the **Proposed changes** section) using the wording `Addresses #<issue_number>`
- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Basic linting passes locally with my changes
- [x] I have added necessary documentation (if appropriate)
- [x] I have updated the Changelog with a brief description of my changes
