### PR TITLE
Automate the release process trigger weekly

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -77,6 +77,12 @@
             ]
         },
         {
+            "description": "Allow automerge for minor updates of certain packages",
+            "matchPackageNames": [
+                "certifi"
+            ]
+        },
+        {
             "automerge": false,
             "description": "Group together all python-semantic-release dependencies",
             "groupName": "python-semantic-release dependencies",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,7 +3,8 @@
     "dependencyDashboard": true,
     "extends": [
         "config:best-practices",
-        "group:githubArtifactActions"
+        "group:githubArtifactActions",
+        ":separatePatchReleases"
     ],
     "ignoreDeps": [
         "tektronix/python-package-ci-cd"

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -83,6 +83,13 @@
             ]
         },
         {
+            "description": "Group together all pydantic dependencies",
+            "groupName": "pydantic dependencies",
+            "matchPackageNames": [
+                "/^pydantic/"
+            ]
+        },
+        {
             "automerge": false,
             "description": "Group together all python-semantic-release dependencies",
             "groupName": "python-semantic-release dependencies",

--- a/.github/workflows/_reusable-package-release.yml
+++ b/.github/workflows/_reusable-package-release.yml
@@ -92,6 +92,9 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332  # v4.1.7
+        with:
+          fetch-depth: 0
+          fetch-tags: true
       - name: python-versions-array input missing
         if: ${{ inputs.build-and-publish-python-package == true && (inputs.python-versions-array == null || inputs.python-versions-array == '') }}
         run: |
@@ -127,6 +130,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332  # v4.1.7
         with:
           fetch-depth: 0
+          fetch-tags: true
           token: ${{ secrets.checkout-token }}
       - if: ${{ endsWith(github.repository, '/python-package-ci-cd') }}  # Run the local action when this is run in the python-package-ci-cd repository
         uses: ./actions/find_unreleased_changelog_items

--- a/.github/workflows/package-release.yml
+++ b/.github/workflows/package-release.yml
@@ -12,6 +12,8 @@ on:
           minor for backward compatible larger changes,
           major for non-backward compatible changes.
         options: [patch, minor, major]
+  schedule:
+    - cron: 0 16 * * 2
 concurrency:
   group: pypi
 jobs:
@@ -23,7 +25,7 @@ jobs:
       build-and-publish-python-package: false
       commit-user-name: ${{ vars.TEK_OPENSOURCE_NAME }}
       commit-user-email: ${{ vars.TEK_OPENSOURCE_EMAIL }}
-      release-level: ${{ inputs.release-level }}
+      release-level: ${{ inputs.release-level || 'patch' }}
       previous-changelog-filepath: python_semantic_release_templates/.previous_changelog_for_template.md
       previous-release-notes-filepath: python_semantic_release_templates/.previous_release_notes_for_template.md
     permissions:

--- a/.github/workflows/test-actions.yml
+++ b/.github/workflows/test-actions.yml
@@ -101,6 +101,8 @@ jobs:
           MULTILINE_STRING=$(cat <<'EOF'
           ## Workflow Inputs
           - release-level: patch
+          ## PRs Merged Since Last Release
+
           ## Incoming Changes
           Things to be included in the next release go here.
           ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Things to be included in the next release go here.
 ### Added
 
 - Added the ability for the `update_development_dependencies` action to accept a comma-separated, multiline string
+- Added all PRs merged since the last release to the job summary for the release workflow
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Things to be included in the next release go here.
 
 ### Changed
 
+- Bumped dependency versions.
 - Changed the `_reusable-update-python-and-pre-commit-dependencies.yml` workflow to no longer only work on PRs from Dependabot, users will now need to apply any conditional login in the calling workflow.
 - Updated the `_reusable-update-python-and-pre-commit-dependencies.yml` workflow to allow using [`renovate`](https://docs.renovatebot.com/) instead of Dependabot to update dependencies.
 

--- a/actions/find_unreleased_changelog_items/Dockerfile
+++ b/actions/find_unreleased_changelog_items/Dockerfile
@@ -5,6 +5,9 @@ COPY requirements.txt /requirements.txt
 COPY main.py /main.py
 
 # Install dependencies
+RUN apk update && \
+    apk add --no-cache git && \
+    rm -rf /var/cache/apk/*
 RUN python -m pip install --no-cache-dir --requirement /requirements.txt
 
 # Run the Python script as the entrypoint

--- a/actions/find_unreleased_changelog_items/main.py
+++ b/actions/find_unreleased_changelog_items/main.py
@@ -17,10 +17,25 @@ from __future__ import annotations
 import os
 import pathlib
 import re
+import shlex
 import shutil
 import subprocess
 
 CHANGELOG_FILE = pathlib.Path("./CHANGELOG.md")
+
+
+def run_cmd_in_subprocess(command: str) -> str:
+    """Run the given command in a subprocess and return the result.
+
+    Args:
+        command: The command string to send.
+
+    Returns:
+        The output from the command.
+    """
+    command = command.replace("\\", "/")
+    print(f"\nExecuting command: {command}")
+    return subprocess.check_output(shlex.split(command)).decode()  # noqa: S603
 
 
 def get_latest_tag() -> str | None:
@@ -30,8 +45,7 @@ def get_latest_tag() -> str | None:
         The latest tag as a string if it exists, otherwise None.
     """
     try:
-        result = subprocess.check_output(["git", "describe", "--tags", "--abbrev=0"])  # noqa: S603,S607
-        return result.decode().strip()
+        return run_cmd_in_subprocess("git describe --tags --abbrev=0").strip()
     except subprocess.CalledProcessError:
         return None
 
@@ -46,9 +60,7 @@ def get_commit_messages(since_tag: str | None = None) -> list[str]:
         A list of commit messages as strings.
     """
     range_spec = f"{since_tag}..HEAD" if since_tag else "HEAD"
-
-    result = subprocess.check_output(["git", "log", range_spec, "--pretty=format:%s"])  # noqa: S603,S607
-    return result.decode().splitlines()
+    return run_cmd_in_subprocess(f"git log {range_spec} --pretty=format:%s").splitlines()
 
 
 def main() -> None:
@@ -105,7 +117,10 @@ def main() -> None:
     # If running in GitHub Actions, and the release_level is set, send the release level and
     # incoming changes to the GitHub Summary
     if release_level:
-        subprocess.check_call(["git", "config", "--global", "--add", "safe.directory", "."])  # noqa: S603,S607
+        root_dir = pathlib.Path.cwd()
+        run_cmd_in_subprocess(
+            f'git config --global --add safe.directory "{root_dir.resolve().as_posix()}"'
+        )
         commit_messages = get_commit_messages(since_tag=get_latest_tag())
 
         pr_regex = re.compile(r"\(#\d+\)$")
@@ -116,7 +131,7 @@ def main() -> None:
             f"## Incoming Changes\n{release_notes_content.replace('## Unreleased', '').strip()}\n"
         )
         print(
-            f"Adding the following contents to the GitHub Workflow Summary:\n\n{summary_contents}"
+            f"\nAdding the following contents to the GitHub Workflow Summary:\n\n{summary_contents}"
         )
         with open(os.environ["GITHUB_STEP_SUMMARY"], "a") as summary_file:  # noqa: PTH123
             summary_file.write(summary_contents)

--- a/actions/find_unreleased_changelog_items/main.py
+++ b/actions/find_unreleased_changelog_items/main.py
@@ -105,6 +105,7 @@ def main() -> None:
     # If running in GitHub Actions, and the release_level is set, send the release level and
     # incoming changes to the GitHub Summary
     if release_level:
+        subprocess.check_call(["git", "config", "--global", "--add", "safe.directory", "."])  # noqa: S603,S607
         commit_messages = get_commit_messages(since_tag=get_latest_tag())
 
         pr_regex = re.compile(r"\(#\d+\)$")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,7 @@ pytest-env = "^1.1.3"
 pytest-github-report = "^0.0.1"
 pytest-html = "^4.1.1"
 pytest-order = "^1.2.1"
+pytest-subprocess = "^1.5.2"
 
 [tool.pyright]
 ignore = [
@@ -109,7 +110,8 @@ junit_family = "xunit2"
 junit_logging = "all"
 markers = [
   'docs',
-  'order'
+  'order',
+  'slow'
 ]
 pythonpath = "."
 xfail_strict = true

--- a/python_semantic_release_templates/CHANGELOG.md.j2
+++ b/python_semantic_release_templates/CHANGELOG.md.j2
@@ -1,7 +1,7 @@
 {%- import ".macros.j2" as macros %}
 
 {%- call(output) macros.populate_variables() %}
-    {%- filter replace("## Unreleased", "## Unreleased\n\nThings to be included in the next release go here.\n\n---\n\n## " + output[0] + " (" + output[1] + ")" + output[2]) %}
+    {%- filter replace("## Unreleased", "## Unreleased\n\nThings to be included in the next release go here.\n\n### Changed\n\n- Bumped dependency versions.\n\n---\n\n## " + output[0] + " (" + output[1] + ")" + output[2]) %}
         {%- filter replace("Things to be included in the next release go here.\n\n", "") %}
             {%- include ".previous_changelog_for_template.md" %}
         {%- endfilter %}


### PR DESCRIPTION
## Proposed changes

This creates a weekly patch release for the repository that will include all merged dependency updates.

This also adds a new section to the job summary of the release job that will list all merged PRs for the reviewer to look over prior to approving the release.

It also groups all pydantic dependency updates together to enable them to pass builds.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] New feature (non-breaking change which adds functionality)
- [x] Functionality update (non-breaking change which updates or changes existing functionality)
- [x] CI/CD update (an update to the CI/CD workflows, scripts, and/or configurations)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have followed the guidelines in the [CONTRIBUTING](https://github.com/tektronix/python-package-ci-cd/blob/main/CONTRIBUTING.md) document
- [x] I have signed the CLA
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/tektronix/python-package-ci-cd/pulls) for the same update/change
- [x] I have created (or updated) an [Issue](https://github.com/tektronix/python-package-ci-cd/issues) to track the status of this update/change and updated the link in this PR description (see above in the **Proposed changes** section) using the wording `Addresses #<issue_number>`
- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Basic linting passes locally with my changes
- [x] I have added necessary documentation (if appropriate)
- [x] I have updated the Changelog with a brief description of my changes
