### PR TITLE
Enable automerge for pre commit hook updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -88,7 +88,8 @@
             "automerge": true,
             "description": "Allow automatically merging minor updates of certain packages",
             "matchPackageNames": [
-                "certifi"
+                "certifi",
+                "trove-classifiers"
             ],
             "matchUpdateTypes": [
                 "minor"

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -1,5 +1,5 @@
 ---
-name: Auto approve Renovate PRs
+name: Auto approve Renovate/pre-commit.ci PRs
 on:
   pull_request_target:
 jobs:

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -6,8 +6,15 @@ jobs:
   auto-approve:
     runs-on: ubuntu-latest
     permissions:
+      contents: write
       pull-requests: write
     if: (github.actor == 'renovate[bot]' && startsWith(github.head_ref, 'renovate/automerge/'))
       || (github.actor == 'pre-commit-ci[bot]' && startsWith(github.head_ref, 'pre-commit-ci-update-config'))
     steps:
       - uses: hmarr/auto-approve-action@f0939ea97e9205ef24d872e76833fa908a770363  # v4.0.0
+      - name: Enable auto-merge for pre-commit.ci autoupdate PRs
+        if: github.actor == 'pre-commit-ci[bot]' && startsWith(github.head_ref, 'pre-commit-ci-update-config')
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        run: gh pr merge --auto --merge "$PR_URL"


### PR DESCRIPTION
## Proposed changes

This enables GitHub's auto-merge feature for pre-commit.ci autoupdate PRs.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] CI/CD update (an update to the CI/CD workflows, scripts, and/or configurations)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have followed the guidelines in the [CONTRIBUTING](https://github.com/tektronix/python-package-ci-cd/blob/main/CONTRIBUTING.md) document
- [x] I have signed the CLA
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/tektronix/python-package-ci-cd/pulls) for the same update/change
- [x] I have created (or updated) an [Issue](https://github.com/tektronix/python-package-ci-cd/issues) to track the status of this update/change and updated the link in this PR description (see above in the **Proposed changes** section) using the wording `Addresses #<issue_number>`
- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Basic linting passes locally with my changes
- [x] I have added necessary documentation (if appropriate)
- [x] I have updated the Changelog with a brief description of my changes
