### PR TITLE
chore: Update renovate config to include the new version of Python in the commit and Pull Request title

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -137,7 +137,7 @@
         },
         {
             "additionalBranchPrefix": "",
-            "commitMessageSuffix": " in all dependant actions",
+            "commitMessageSuffix": " to v{{newMajor}}.{{newMinor}} in all dependant actions",
             "description": "Group together all Python (official) version updates",
             "groupName": "python version",
             "matchDepNames": [


### PR DESCRIPTION
## Proposed changes

chore: Update renovate config to include the new version of Python in the commit and Pull Request title

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Functionality update (non-breaking change which updates or changes existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] CI/CD update (an update to the CI/CD workflows, scripts, and/or configurations)
- [ ] Documentation update (an update to enhance the user experience when reading through the docs)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have followed the guidelines in the [CONTRIBUTING](https://github.com/tektronix/python-package-ci-cd/blob/main/CONTRIBUTING.md) document
- [x] I have signed the CLA
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/tektronix/python-package-ci-cd/pulls) for the same update/change
- [ ] I have created (or updated) an [Issue](https://github.com/tektronix/python-package-ci-cd/issues) to track the status of this update/change and updated the link in this PR description (see above in the **Proposed changes** section) using the wording `Addresses #<issue_number>`
- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Basic linting passes locally with my changes
- [x] I have added necessary documentation (if appropriate)
- [x] I have updated the Changelog with a brief description of my changes
