### PR TITLE
fix: Add missing packages to the dependency updater action

### DIFF
--- a/.github/workflows/test-actions.yml
+++ b/.github/workflows/test-actions.yml
@@ -159,7 +159,7 @@ jobs:
           update-pre-commit: true
           run-pre-commit: true
           dependency-dict: '{"dev": ["pyright"]}'
-          pre-commit-repo-update-skip-list: https://github.com/pre-commit/pre-commit-hooks,https://github.com/executablebooks/mdformat
+          pre-commit-repo-update-skip-list: https://github.com/pre-commit/pre-commit-hooks,https://github.com/hukkin/mdformat
           pre-commit-hook-skip-list: remove-tabs,forbid-tabs,check-readthedocs,check-dependabot,check-github-actions,check-github-workflows,commitizen,blacken-docs,yamlfix,hadolint,mdformat,markdown-link-check,check-poetry,toml-sort-fix,pyright,poetry-audit,ruff,ruff-format,docformatter,renovate-config-validator,actionlint
           export-dependency-groups: |
             actions-update_development_dependencies:actions/update_development_dependencies,

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -80,7 +80,7 @@ repos:
       - id: hadolint
         args: [--ignore=DL3008, --ignore=DL3018]
   - repo: https://github.com/hukkin/mdformat
-    rev: 08fba30538869a440b5059de90af03e3502e35fb  # frozen: 0.7.17
+    rev: ff29be1a1ba8029d9375882aa2c812b62112a593  # frozen: 0.7.22
     hooks:
       - id: mdformat
         args: [--number, --end-of-line, keep]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -80,7 +80,7 @@ repos:
       - id: hadolint
         args: [--ignore=DL3008, --ignore=DL3018]
   - repo: https://github.com/hukkin/mdformat
-    rev: ff29be1a1ba8029d9375882aa2c812b62112a593  # frozen: 0.7.22
+    rev: 08fba30538869a440b5059de90af03e3502e35fb  # frozen: 0.7.17
     hooks:
       - id: mdformat
         args: [--number, --end-of-line, keep]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ Valid subsections within a version are:
 
 Things to be included in the next release go here.
 
+### Fixed
+
+- Added rust and cargo to the Docker image used for the update dependencies action.
+
 ### Changed
 
 - Bumped dependency versions.

--- a/actions/update_development_dependencies/Dockerfile
+++ b/actions/update_development_dependencies/Dockerfile
@@ -6,7 +6,11 @@ COPY main.py /main.py
 
 # Install dependencies
 RUN apk update && \
-    apk add --no-cache git && \
+    apk add --no-cache \
+        cargo \
+        git \
+        rust \
+    && \
     rm -rf /var/cache/apk/* && \
     python -m pip install --no-cache-dir --requirement /requirements.txt
 

--- a/doc_config/.linkchecker.ini
+++ b/doc_config/.linkchecker.ini
@@ -7,4 +7,6 @@ checkextern=1
 ignore=
     /fonts/
     mailto:
+    https://github.com/tektronix/python-package-ci-cd/pull/
+    https://github.com/tektronix/python-package-ci-cd/issues/
 ignorewarnings=http-redirected,http-rate-limited


### PR DESCRIPTION
## Proposed changes

The dependency updater action is missing some rust packages, causing python package installation during pre-commit runs to fail. This PR fixes that issue.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Functionality update (non-breaking change which updates or changes existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] CI/CD update (an update to the CI/CD workflows, scripts, and/or configurations)
- [ ] Documentation update (an update to enhance the user experience when reading through the docs)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have followed the guidelines in the [CONTRIBUTING](https://github.com/tektronix/python-package-ci-cd/blob/main/CONTRIBUTING.md) document
- [x] I have signed the CLA
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/tektronix/python-package-ci-cd/pulls) for the same update/change
- [ ] I have created (or updated) an [Issue](https://github.com/tektronix/python-package-ci-cd/issues) to track the status of this update/change and updated the link in this PR description (see above in the **Proposed changes** section) using the wording `Addresses #<issue_number>`
- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Basic linting passes locally with my changes
- [x] I have added necessary documentation (if appropriate)
- [x] I have updated the Changelog with a brief description of my changes
